### PR TITLE
Update requirements.txt

### DIFF
--- a/pyMixtComp/python/requirements.txt
+++ b/pyMixtComp/python/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-pandas
+pandas==1.4.0
 scikit-learn
 scipy
 matplotlib


### PR DESCRIPTION
Fixing the failing pyMixtComp tests by downgrading pandas. The error is due to the incompatibility of the latest pandas version with other dependencies. 
Ref: https://github.com/facebook/Ax/issues/1153