### PR TITLE
Adding SUFFIX to target properties

### DIFF
--- a/pyMixtComp/src/lib/CMakeLists.txt
+++ b/pyMixtComp/src/lib/CMakeLists.txt
@@ -19,5 +19,5 @@ target_link_libraries(pyMixtCompBridge
   ${PYTHON_LIBRARIES})
 
 # don't prepend wrapper library name with lib
-set_target_properties(pyMixtCompBridge PROPERTIES PREFIX "")
+set_target_properties(pyMixtCompBridge PROPERTIES PREFIX "" SUFFIX ".so")
 


### PR DESCRIPTION
On Linux, the compiler generates by default a .so file and .dylib on macOS. Shared libraries with .dylib extensions are un-importable directly by a python script like a .so file. Ref: https://stackoverflow.com/questions/2488016/how-to-make-python-load-dylib-on-osx.

Therefore, a suffix is needed to force the compiler to generate a .so on macOS and Linux.